### PR TITLE
2024f用にREADMEを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## 公開手順 (jn.sfc.keio.ac.jp)
 変更を確認する際ブラウザーのキャッシュを消すように。
-1. daliにssh
-2. jnにssh
-3. `/var/www/kg/wellcomp`へcd
+1. JNNET VPNに接続
+2. `jn.sfc.keio.ac.jp`にssh
+3. `/srv/www/wellcomp`へcd
 4. `git pull origin master` (sudoが必要です)
 
 ## メンテナンス


### PR DESCRIPTION
## 対応内容
- daliが廃止されたためVPN接続方法を修正
- cd先を更新