### PR TITLE
デプロイのCI/CD修正

### DIFF
--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -7,19 +7,26 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-    - name: Install WireGuard
-      run: |
-        sudo apt update
-        sudo apt install -y wireguard openresolv
+      - name: Install WireGuard
+        run: |
+          sudo apt update
+          sudo apt install -y wireguard openresolv
 
-    - name: Setup WireGuard
-      run: |
-        echo "${{ secrets.VPN_CONF }}" | base64 -d > /tmp/wg0.conf
-        sudo mv /tmp/wg0.conf /etc/wireguard/wg0.conf
-        sudo wg-quick up wg0
+      - name: Setup WireGuard
+        run: |
+          echo "${{ secrets.VPN_CONF }}" | base64 -d > /tmp/wg0.conf
+          sudo mv /tmp/wg0.conf /etc/wireguard/wg0.conf
+          sudo wg-quick up wg0
 
-    - name: Deploy file
-      run: |
-        echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
-        chmod 600 /tmp/id_rsa
-        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r . wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp
+      - name: Compress files for upload
+        run: tar -czf site.tar.gz .
+
+      - name: Deploy file
+        run: |
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
+          chmod 600 /tmp/id_rsa
+          scp -i /tmp/id_rsa -o StrictHostKeyChecking=no site.tar.gz wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp
+
+      - name: Extract files on the server
+        run: |
+          ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp "cd /srv/www/wellcomp && tar -xzf site.tar.gz && rm site.tar.gz"

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -7,12 +7,19 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-    - name: dali server ssh connection
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.HOST }}
-        username: kenty
-        key: ${{ secrets.WELLCOMP_SECRET }}
-        port: 22
-        script: |
-         
+    - name: Install WireGuard
+      run: |
+        sudo apt update
+        sudo apt install -y wireguard openresolv
+
+    - name: Setup WireGuard
+      run: |
+        echo "${{ secrets.VPN_CONF }}" | base64 -d > /tmp/wg0.conf
+        sudo mv /tmp/wg0.conf /etc/wireguard/wg0.conf
+        sudo wg-quick up wg0
+
+    - name: Deploy file
+      run: |
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
+        chmod 600 /tmp/id_rsa
+        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./dist/* jnroot@www.jn.sfc.keio.ac.jp:/var/www/html

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -22,4 +22,4 @@ jobs:
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
         chmod 600 /tmp/id_rsa
-        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./dist/* wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp
+        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./* wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -18,18 +18,13 @@ jobs:
           sudo mv /tmp/wg0.conf /etc/wireguard/wg0.conf
           sudo wg-quick up wg0
 
-      - name: test
-        run: ls -la
-
-      - name: Compress files for upload
-        run: tar --exclude='.git' --exclude='site.tar.gz' --warning=no-file-changed -czf site.tar.gz .
-
-      - name: Deploy file
+      - name: SSH to the server
         run: |
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
           chmod 600 /tmp/id_rsa
-          scp -i /tmp/id_rsa -o StrictHostKeyChecking=no site.tar.gz wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp
+          ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp
 
-      - name: Extract files on the server
+      - name: Pull the code on the server
         run: |
-          ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp "cd /srv/www/wellcomp && tar -xzf site.tar.gz && rm site.tar.gz"
+          cd /srv/www/wellcomp
+          git pull

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -22,4 +22,4 @@ jobs:
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
         chmod 600 /tmp/id_rsa
-        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./* wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp
+        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r * wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: SSH to the server and pull the code
         run: |
-          ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp
-          cd /srv/www/wellcomp
-          git pull
-          exit
+          ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp << 'EOF'
+            cd /srv/www/wellcomp || exit 1
+            git pull || exit 1
+          EOF

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -22,4 +22,4 @@ jobs:
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
         chmod 600 /tmp/id_rsa
-        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./dist/* jnroot@www.jn.sfc.keio.ac.jp:/var/www/html
+        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./dist/* jnroot@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -19,7 +19,7 @@ jobs:
           sudo wg-quick up wg0
 
       - name: Compress files for upload
-        run: tar -czf site.tar.gz .
+        run: tar --exclude='.git' --exclude='site.tar.gz' -czf site.tar.gz .
 
       - name: Deploy file
         run: |

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -18,8 +18,11 @@ jobs:
           sudo mv /tmp/wg0.conf /etc/wireguard/wg0.conf
           sudo wg-quick up wg0
 
+      - name: test
+        run: ls -la
+
       - name: Compress files for upload
-        run: tar --exclude='.git' --exclude='site.tar.gz' -czf site.tar.gz .
+        run: tar --exclude='.git' --exclude='site.tar.gz' --warning=no-file-changed -czf site.tar.gz .
 
       - name: Deploy file
         run: |

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -18,13 +18,14 @@ jobs:
           sudo mv /tmp/wg0.conf /etc/wireguard/wg0.conf
           sudo wg-quick up wg0
 
-      - name: SSH to the server
+      - name: Setup SSH key
         run: |
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
           chmod 600 /tmp/id_rsa
-          ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp
 
-      - name: Pull the code on the server
+      - name: SSH to the server and pull the code
         run: |
+          ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp
           cd /srv/www/wellcomp
           git pull
+          exit

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -22,4 +22,4 @@ jobs:
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
         chmod 600 /tmp/id_rsa
-        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r * wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp
+        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r . wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp

--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -22,4 +22,4 @@ jobs:
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > /tmp/id_rsa
         chmod 600 /tmp/id_rsa
-        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./dist/* jnroot@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp
+        scp -i /tmp/id_rsa -o StrictHostKeyChecking=no -r ./dist/* wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp:/srv/www/wellcomp

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # WellComp HP
 
 ## 公開手順 (jn.sfc.keio.ac.jp)
+GitHub Actions (CI/CD) が設定されているため、Actionsから `Deployment Workflow` → `Run Workflow` を選択することで、自動で公開されます。
+
+#### 手動でデプロイする
 変更を確認する際ブラウザーのキャッシュを消すように。
 1. JNNET VPNに接続
-2. `www.jn.sfc.keio.ac.jp`にssh
+2. jnにデプロイ用ユーザーでssh (`ssh wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp`)
 3. `/srv/www/wellcomp`へcd
-4. `git pull origin master` (sudoが必要です)
+4. `git pull origin master`
 
 ## メンテナンス
 #### メンバー追加


### PR DESCRIPTION
## 概要
GitHub Actionsが動作するように修正。

Actions -> Deployment Workflow から Run Workflowで手動実行することで、デプロイすることができます。

## 対応内容
リポジトリにDeploy Keysを追加し、ssh先でgit pullする形式にしました。
（scpだとgitチェックアウト＆転送を行う必要があり非効率だったため）

## 作業内容
- Settings -> Deploy Keys に `wellcomp-hp-deploy`ユーザーの公開鍵を登録

- Settings -> Secrets にWireGuardのconfファイルと、 `wellcomp-hp-deploy`にsshするための秘密鍵を登録
  - `VPN_CONF`: VPN（WireGuard）のconfファイルをbase64でエンコードしたもの
  - `SSH_PRIVATE_KEY`: `wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp`にsshするための秘密鍵