### PR TITLE
研究業績を追加

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -180,7 +180,7 @@ html, body {
 }
 
 #projects .custom-shape-divider-bottom-1602937784 .shape-fill {
-    fill: #55C5C1;
+    fill: #EEEEEE;
 }
 
 #projects .cards-all {
@@ -214,6 +214,41 @@ html, body {
     color: #00254d;
     font-family: 'Cabin';
     font-weight: 400;
+}
+
+#publications {
+    padding-top: 50px;
+    background-color: #EEEEEE;
+}
+
+#publications .section-text {
+    margin-bottom: 130px;
+}
+
+#publications .section-text p {
+    font-size: 12px;
+}
+
+#publications .custom-shape-divider-bottom-1602938894 {
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    width: 100%;
+    overflow: hidden;
+    line-height: 0;
+    transform: rotate(180deg);
+    background-color: #EEEEEE;
+}
+
+#publications .custom-shape-divider-bottom-1602938894 svg {
+    position: relative;
+    display: block;
+    width: calc(200% + 1.3px);
+    height: 131px;
+}
+
+#publications .custom-shape-divider-bottom-1602938894 .shape-fill {
+    fill: #55C5C1;
 }
 
 #members {
@@ -334,17 +369,20 @@ html, body {
     line-height: 40px;
 }
 
-@media(max-width:768px) {
+@media (max-width: 768px) {
     .header-content h1 {
         font-size: 40px;
     }
+
     .header-content p {
         font-size: 1rem;
     }
+
     #hero .header-logo {
         width: 200px;
         height: 36px;
     }
+
     #hero .header-content h1 {
         font-size: 35px;
     }

--- a/index.html
+++ b/index.html
@@ -199,6 +199,54 @@
 
 </section>
 
+<section id="publications">
+    <div class="container">
+        <div class="col text-center" data-aos="fade-up" data-aos-delay="600" data-aos-offset="0"
+             data-aos-once="true">
+            <h1 class="section-header">Publications</h1>
+        </div>
+
+        <div class="col section-text">
+            <div data-aos="fade-up" data-aos-delay="600" data-aos-offset="0"
+                 data-aos-once="true">
+                <p>Hamanaka, Satoki, et al. “Estimation of User Personality Traits on the Web Using Multi-Task
+                    Learning.” Proceedings of the 24th International Workshop on Mobile Computing Systems and
+                    Applications, 2023, p. 133, https://doi.org/10.1145/3572864.3581580.</p>
+                <p>羽柴彩月, et al. “ユーザビリティの低下による不快感を用いた SNS 利用に対するセルフコントロール手法.”
+                    情報処理学会論文誌, vol. 64, Apr. 2023, pp. 799–813, https://doi.org/10.20729/00225487.</p>
+                <p>Sasaki, Wataru, et al. “Large - Scale Estimation and Analysis of Web Users’ Mood from Web Search
+                    Query and Mobile Sensor Data.” Big Data, vol. 0, 2023, p. null,
+                    https://doi.org/10.1089/big.2022.0211.</p>
+                <p>Katsumata, Kento, et al. “COVIDGuardian: A Machine Learning Approach for Detecting the Three Cs.”
+                    Proceedings of the 12th International Conference on the Internet of Things, 2023, pp. 147–50,
+                    https://doi.org/10.1145/3567445.3569166.</p>
+                <p>佐々木航, et al. “SFC GO：学生同士の繋がりを支援するオンライン体育授業サポートシステム.”
+                    情報処理学会論文誌デジタルプラクティス（TDP）, vol. 3, no. 1, Jan. 2022, pp. 19–33.</p>
+                <p>Hamanaka, Satoki, et al. A Comparative Study of CIPN Symptom Estimation Methods Based on Machine
+                    Learning. 2021, p. 4.</p>
+                <p>Okoshi, Tadashi, et al. “WellComp 2021: Fourth International Workshop on Computing for Well-Being.”
+                    Adjunct Proceedings of the 2021 ACM International Joint Conference on Pervasive and Ubiquitous
+                    Computing and Proceedings of the 2021 ACM International Symposium on Wearable Computers, ACM, 2021,
+                    pp. 108–11, https://doi.org/10.1145/3460418.3479262.</p>
+                <p>Sasaki, Wataru, et al. “Investigating the Occurrence of Selfie-Based Emotional Contagion over Social
+                    Network.” Springer, vol. 11, no. 1, 2021, p. 8, https://doi.org/10.1007/s13278-020-00712-0.</p>
+                <p class="text-center"><a href="https://www.jn.sfc.keio.ac.jp/publication/">すべて表示</a></p>
+            </div>
+        </div>
+    </div>
+
+    <div style="position:relative; background-color:#faf6ff;">
+        <div class="custom-shape-divider-bottom-1602938894">
+            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120"
+                 preserveAspectRatio="none">
+                <path
+                        d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
+                        class="shape-fill"></path>
+            </svg>
+        </div>
+    </div>
+</section>
+
 <section id="members">
     <div class="container">
         <div class="col text-center" data-aos="fade-up" data-aos-delay="600" data-aos-offset="0"

--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
                 <a class="nav-link" href="#projects">Projects</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="#publications">Publications</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="#members">Members</a>
             </li>
             <li class="nav-item">


### PR DESCRIPTION
数が多かったため2021年以降のジャーナル論文，国際会議（口頭）に絞って追加

## スクリーンショット
![image](https://github.com/user-attachments/assets/224ffe8a-1dee-42c3-a818-d92a780dc926)
