### PR TITLE
fix: デプロイCIのgit pullでブランチ未追跡エラーが発生する問題を修正

### DIFF
--- a/.github/workflows/auto_deploy_workflow.yml
+++ b/.github/workflows/auto_deploy_workflow.yml
@@ -30,5 +30,6 @@ jobs:
         run: |
           ssh -i /tmp/id_rsa -o StrictHostKeyChecking=no wellcomp-hp-deploy@www.jn.sfc.keio.ac.jp << 'EOF'
             cd /srv/www/wellcomp || exit 1
-            git pull || exit 1
+            git checkout master || exit 1
+            git pull origin master || exit 1
           EOF


### PR DESCRIPTION
## 概要

デプロイCIが `git pull` 実行時に「ブランチのトラッキング情報がない」エラーで失敗していた問題を修正

```
There is no tracking information for the current branch.
    git branch --set-upstream-to=origin/<branch> feature/change-kg-name
```

## 変更内容

`git pull` の前に `git checkout master` を追加し、常に master ブランチに戻してからプルするように変更

```diff
- git pull || exit 1
+ git checkout master || exit 1
+ git pull origin master || exit 1
```

## テスト

- [ ] CIが正常に完了することを確認